### PR TITLE
Disable certbot.timer when disabling cron

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,3 +5,10 @@
     path: /etc/cron.d/certbot
     state: absent
   when: certbot_disable_certbot_cron
+
+- name: Disable certbot timer
+  service:
+    name: certbot.timer
+    state: stopped
+    enabled: false
+  when: certbot_disable_certbot_cron


### PR DESCRIPTION
Debian 9 uses systemd timer instead of cron by default.